### PR TITLE
Allowing a prefix to be used during construction of CrudUrlHandler, t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.0.11
+
+Added: Allow a prefix to be set during construction of CrudUrlHandler to be used as leafClassStub 
+
+
 ### 1.0.10
 
 Added: Supported closures along with class names.

--- a/src/UrlHandlers/CrudUrlHandler.php
+++ b/src/UrlHandlers/CrudUrlHandler.php
@@ -25,9 +25,9 @@ use Rhubarb\Stem\UrlHandlers\ModelCollectionHandler;
 
 class CrudUrlHandler extends LeafRestUrlHandler
 {
-    private $namespaceBase;
+    protected $namespaceBase;
 
-    private $leafClassStub;
+    protected $leafClassStub;
 
     public function __construct($modelName, $namespaceBase, $additionalPresenterClassNameMap = [], $childUrlHandlers = [], $prefix = null)
     {

--- a/src/UrlHandlers/CrudUrlHandler.php
+++ b/src/UrlHandlers/CrudUrlHandler.php
@@ -29,7 +29,7 @@ class CrudUrlHandler extends LeafRestUrlHandler
 
     private $leafClassStub;
 
-    public function __construct($modelName, $namespaceBase, $additionalPresenterClassNameMap = [], $childUrlHandlers = [])
+    public function __construct($modelName, $namespaceBase, $additionalPresenterClassNameMap = [], $childUrlHandlers = [], $prefix)
     {
         $namespaceBase = rtrim($namespaceBase, "\\");
         $this->namespaceBase = $namespaceBase;
@@ -37,7 +37,11 @@ class CrudUrlHandler extends LeafRestUrlHandler
         // Get the parent folder which will become our collection presenter
         $parts = explode("/", str_replace("\\", "/", $namespaceBase));
 
-        $this->leafClassStub = $parts[sizeof($parts) - 1];
+        if (isset($prefix)) {
+            $this->leafClassStub = $prefix;
+        } else {
+            $this->leafClassStub = $parts[ sizeof($parts) - 1 ];
+        }
 
         parent::__construct(
             $modelName,

--- a/src/UrlHandlers/CrudUrlHandler.php
+++ b/src/UrlHandlers/CrudUrlHandler.php
@@ -29,17 +29,17 @@ class CrudUrlHandler extends LeafRestUrlHandler
 
     private $leafClassStub;
 
-    public function __construct($modelName, $namespaceBase, $additionalPresenterClassNameMap = [], $childUrlHandlers = [], $prefix)
+    public function __construct($modelName, $namespaceBase, $additionalPresenterClassNameMap = [], $childUrlHandlers = [], $prefix = null)
     {
         $namespaceBase = rtrim($namespaceBase, "\\");
         $this->namespaceBase = $namespaceBase;
 
-        // Get the parent folder which will become our collection presenter
-        $parts = explode("/", str_replace("\\", "/", $namespaceBase));
-
         if (isset($prefix)) {
             $this->leafClassStub = $prefix;
         } else {
+            // Get the parent folder which will become our collection presenter
+            $parts = explode("/", str_replace("\\", "/", $namespaceBase));
+
             $this->leafClassStub = $parts[ sizeof($parts) - 1 ];
         }
 


### PR DESCRIPTION
…o be used as leafClassStub instead of the last part of the namespace when it is set.