### PR TITLE
Toggleable header/button bar in generic cruds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.1.3
+
+Added: Flags in GenericCrudModel to hide buttons and header on GenericItemView
+
 ### 1.1.2
 
 Changed: css classes for header are now changeable

--- a/src/Generic/GenericCrudModel.php
+++ b/src/Generic/GenericCrudModel.php
@@ -7,4 +7,6 @@ use Rhubarb\Leaf\Crud\Leaves\CrudModel;
 class GenericCrudModel extends CrudModel
 {
     public $errors = [];
+    public $showButtonBar = true;
+    public $showHeader = true;
 }

--- a/src/Generic/GenericItemView.php
+++ b/src/Generic/GenericItemView.php
@@ -35,24 +35,40 @@ abstract class GenericItemView extends CrudView
     {
         $htmlPageSettings = HtmlPageSettings::singleton();
 
-        $delete = $this->model->restModel->isNewRecord() ? '' : $this->leaves['Delete'];
         print <<<HTML
         <main class="c-main">
-            {$this->getHeaderBarHTML()}
-            <div class="u-pad o-wrap">
+HTML;
+        if($this->model->showHeader) {
+            $this->getHeaderBarHTML();
+        }
+        print <<<HTML
+            <div
+} class="u-pad o-wrap">
                 <h1 class="u-epsilon c-heading">{$htmlPageSettings->pageTitle}</h1>
                 
 HTML;
 
         $this->printInputs();
 
+        if($this->model->showButtonBar)
+        {
+            $this->printButtonBar();
+        }
+
         print <<<HTML
-                <div class="u-pad-top-bottom o-flex">
+            </div>
+        </main>
+HTML;
+    }
+
+    protected function printButtonBar()
+    {
+        $delete = $this->model->restModel->isNewRecord() ? '' : $this->leaves['Delete'];
+        print <<<HTML
+        <div class="u-pad-top-bottom o-flex">
                     <div class="o-flex__item">{$this->leaves['Save']}{$this->leaves['Cancel']}</div>
                     <div>{$delete}</div>
                 </div>
-            </div>
-        </main>
 HTML;
     }
 


### PR DESCRIPTION
Added $showButtonBar and $showHeader for generic cruds, so that items can be displayed without these items.